### PR TITLE
Update cassandra.service.j2

### DIFF
--- a/templates/cassandra.service.j2
+++ b/templates/cassandra.service.j2
@@ -6,12 +6,12 @@ After=network.target
 
 [Service]
 PIDFile={{cassandra_home_dir}}/run/cassandra.pid
-ExecStartPre=-/usr/bin/mkdir -p {{cassandra_eff_hints_directory}}
+ExecStartPre=-mkdir -p {{cassandra_eff_hints_directory}}
 {% for d in cassandra_eff_data_file_directories %}
-ExecStartPre=-/usr/bin/mkdir -p {{d}}
+ExecStartPre=-mkdir -p {{d}}
 {% endfor %}
-ExecStartPre=-/usr/bin/mkdir -p {{cassandra_eff_commitlog_directory}}
-ExecStartPre=-/usr/bin/mkdir -p {{cassandra_eff_saved_caches}}
+ExecStartPre=-mkdir -p {{cassandra_eff_commitlog_directory}}
+ExecStartPre=-mkdir -p {{cassandra_eff_saved_caches}}
 ExecStart={{cassandra_home_dir}}/bin/cassandra -f -R -p {{cassandra_home_dir}}/run/cassandra.pid
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
mkdir path is /bin/mkdir on ubuntu variants.
since /usr/bin and /bin already exist in PATH, no need to give /usr/bin prefix..